### PR TITLE
Add customization of the query and the no results message

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Distribution:
 
 * [***data-no-results***="No results for '{}'."] (Optional): The message to display when no results are found.
 
-  Each sequence of 2 curly brackets `{}` will be substituted with the queried text.
+  The sequence of 2 curly brackets `{}` will be substituted with the queried text.
 
 ### Styling and theming
 

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Distribution:
   Include [typesense-minibar-foot.css](./typesense-minibar-foot.css) to render the official
   Typesense wordmark instead.
 
-* [***data-search-params***='{}'] (Optional): Modify search query parameters.
+* [***data-search-params***=""] (Optional): Modify search query parameters.
 
   Each key-value pair will be added as a search query parameter, or will override the default value.
-  This property must be a valid JSON document.
+  This property must be a valid URL parameters sequence, e.g. `"key1=value1&key2=value2"`.
 
   Refer to [typesense-minibar.js](./typesense-minibar.js) for the default search query parameters.
   Refer to [Typesense documentation](https://typesense.org/docs/0.24.1/api/search.html#search-parameters)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Distribution:
   Refer to [Typesense documentation](https://typesense.org/docs/0.24.1/api/search.html#search-parameters)
   for all the valid parameters.
 
+* [***data-no-results***="No results for '{}'."] (Optional): The message to display when no results are found.
+
+  Each sequence of 2 curly brackets `{}` will be substituted with the queried text.
+
 ### Styling and theming
 
 The accompanying stylesheet exposes **CSS variables** that you can override to

--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ Distribution:
   Include [typesense-minibar-foot.css](./typesense-minibar-foot.css) to render the official
   Typesense wordmark instead.
 
+* [***data-search-params***='{}'] (Optional): Modify search query parameters.
+
+  Each key-value pair will be added as a search query parameter, or will override the default value.
+  This property must be a valid JSON document.
+
+  Refer to [typesense-minibar.js](./typesense-minibar.js) for the default search query parameters.
+  Refer to [Typesense documentation](https://typesense.org/docs/0.24.1/api/search.html#search-parameters)
+  for all the valid parameters.
+
 ### Styling and theming
 
 The accompanying stylesheet exposes **CSS variables** that you can override to

--- a/typesense-minibar.js
+++ b/typesense-minibar.js
@@ -17,6 +17,7 @@ globalThis.tsminibar = function tsminibar (form) {
     'x-typesense-api-key': form.dataset.key,
     ...JSON.parse(form.dataset.searchParams || '{}')
   });
+  const noResults = form.dataset.noResults || "No results for '{}'.";
 
   const input = form.querySelector('input[type=search]');
   const listbox = document.createElement('div');
@@ -148,7 +149,7 @@ globalThis.tsminibar = function tsminibar (form) {
     listbox.hidden = !state.open;
     form.classList.toggle('tsmb-form--open', state.open);
     if (state.open) {
-      listbox.innerHTML = (state.hits.map((hit, i) => `<div role="option"${i === state.cursor ? ' aria-selected="true"' : ''}>${hit.lvl0 ? `<div class="tsmb-suggestion_group">${hit.lvl0}</div>` : ''}<a href="${hit.url}" tabindex="-1"><div class="tsmb-suggestion_title">${hit.title}</div><div class="tsmb-suggestion_content">${hit.content}</div></a></div>`).join('') || `<div class="tsmb-empty">No results for '${escape(state.query)}'.</div>`) + (form.dataset.foot ? '<a href="https://typesense.org" class="tsmb-foot" title="Search by Typesense"></a>' : '');
+      listbox.innerHTML = (state.hits.map((hit, i) => `<div role="option"${i === state.cursor ? ' aria-selected="true"' : ''}>${hit.lvl0 ? `<div class="tsmb-suggestion_group">${hit.lvl0}</div>` : ''}<a href="${hit.url}" tabindex="-1"><div class="tsmb-suggestion_title">${hit.title}</div><div class="tsmb-suggestion_content">${hit.content}</div></a></div>`).join('') || `<div class="tsmb-empty">${noResults.replaceAll('{}', escape(state.query))}</div>`) + (form.dataset.foot ? '<a href="https://typesense.org" class="tsmb-foot" title="Search by Typesense"></a>' : '');
     }
   }
 

--- a/typesense-minibar.js
+++ b/typesense-minibar.js
@@ -149,7 +149,7 @@ globalThis.tsminibar = function tsminibar (form) {
     listbox.hidden = !state.open;
     form.classList.toggle('tsmb-form--open', state.open);
     if (state.open) {
-      listbox.innerHTML = (state.hits.map((hit, i) => `<div role="option"${i === state.cursor ? ' aria-selected="true"' : ''}>${hit.lvl0 ? `<div class="tsmb-suggestion_group">${hit.lvl0}</div>` : ''}<a href="${hit.url}" tabindex="-1"><div class="tsmb-suggestion_title">${hit.title}</div><div class="tsmb-suggestion_content">${hit.content}</div></a></div>`).join('') || `<div class="tsmb-empty">${noResults.replaceAll('{}', escape(state.query))}</div>`) + (form.dataset.foot ? '<a href="https://typesense.org" class="tsmb-foot" title="Search by Typesense"></a>' : '');
+      listbox.innerHTML = (state.hits.map((hit, i) => `<div role="option"${i === state.cursor ? ' aria-selected="true"' : ''}>${hit.lvl0 ? `<div class="tsmb-suggestion_group">${hit.lvl0}</div>` : ''}<a href="${hit.url}" tabindex="-1"><div class="tsmb-suggestion_title">${hit.title}</div><div class="tsmb-suggestion_content">${hit.content}</div></a></div>`).join('') || `<div class="tsmb-empty">${noResults.replace('{}', escape(state.query))}</div>`) + (form.dataset.foot ? '<a href="https://typesense.org" class="tsmb-foot" title="Search by Typesense"></a>' : '');
     }
   }
 

--- a/typesense-minibar.js
+++ b/typesense-minibar.js
@@ -15,7 +15,7 @@ globalThis.tsminibar = function tsminibar (form) {
     snippet_threshold: '8',
     highlight_affix_num_tokens: '12',
     'x-typesense-api-key': form.dataset.key,
-    ...JSON.parse(form.dataset.searchParams || '{}')
+    ...Object.fromEntries(new URLSearchParams(form.dataset.searchParams))
   });
   const noResults = form.dataset.noResults || "No results for '{}'.";
 

--- a/typesense-minibar.js
+++ b/typesense-minibar.js
@@ -1,9 +1,22 @@
 /*! https://github.com/jquery/typesense-minibar 1.0.2 */
 globalThis.tsminibar = function tsminibar (form) {
-  const { origin, key, collection } = form.dataset;
+  const { origin, collection } = form.dataset;
   const group = !!form.dataset.group;
   const cache = new Map();
   const state = { query: '', hits: [], cursor: -1, open: false };
+  const searchParams = new URLSearchParams({
+    per_page: '5',
+    query_by: 'hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,content',
+    include_fields: 'hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,content,url_without_anchor,url,id',
+    highlight_full_fields: 'hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,content',
+    group_by: 'url_without_anchor',
+    group_limit: '1',
+    sort_by: 'item_priority:desc',
+    snippet_threshold: '8',
+    highlight_affix_num_tokens: '12',
+    'x-typesense-api-key': form.dataset.key,
+    ...JSON.parse(form.dataset.searchParams || '{}')
+  });
 
   const input = form.querySelector('input[type=search]');
   const listbox = document.createElement('div');
@@ -104,20 +117,9 @@ globalThis.tsminibar = function tsminibar (form) {
       cache.set(query, hits); // LRU
       return hits;
     }
+    searchParams.set("q", query);
     const resp = await fetch(
-      `${origin}/collections/${collection}/documents/search?` + new URLSearchParams({
-        q: query,
-        per_page: '5',
-        query_by: 'hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,content',
-        include_fields: 'hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,content,url_without_anchor,url,id',
-        highlight_full_fields: 'hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,content',
-        group_by: 'url_without_anchor',
-        group_limit: '1',
-        sort_by: 'item_priority:desc',
-        snippet_threshold: '8',
-        highlight_affix_num_tokens: '12',
-        'x-typesense-api-key': key,
-      }),
+      `${origin}/collections/${collection}/documents/search?` + searchParams,
       { mode: 'cors', credentials: 'omit', method: 'GET' }
     );
     const data = await resp.json();

--- a/typesense-minibar.js
+++ b/typesense-minibar.js
@@ -118,7 +118,7 @@ globalThis.tsminibar = function tsminibar (form) {
       cache.set(query, hits); // LRU
       return hits;
     }
-    searchParams.set("q", query);
+    searchParams.set('q', query);
     const resp = await fetch(
       `${origin}/collections/${collection}/documents/search?` + searchParams,
       { mode: 'cors', credentials: 'omit', method: 'GET' }


### PR DESCRIPTION
The default query is nice, but some customization is often necessary.

The default "no results" message is in english only, there must be an easy way to change that.