### PR TITLE
Add CSS listbox size parameters

### DIFF
--- a/demo/demo-theme.css
+++ b/demo/demo-theme.css
@@ -17,19 +17,19 @@ header > * {
   align-self: center;
 }
 
-header h2 {
-  order: 1;
-}
-
 .demo-logo {
   background-image: url(../assets/logo-text-dark.svg);
 }
 
 header .tsmb-form {
+  width: 30em;
+  margin-left: auto;
   --tsmb-color-base-background: #691c69;
   --tsmb-color-base30: var(--tsmb-color-primary90);
   --tsmb-color-base50: #c090c0;
   --tsmb-color-base90: #c090c0;
+  --tsmb-size-listbox-right: 0;
+  --tsmb-size-listbox-width: calc(min(50rem, 80vw));
 }
 header .tsmb-form:not(:focus-within)::before {
   filter: invert();

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -24,7 +24,7 @@ a:focus {
 header,
 main,
 .demo-stylecontrol {
-  padding: 1rem calc((100% - 65rem) / 2) 0 1rem;
+  padding: 1rem;
 }
 
 .demo-logo {
@@ -36,9 +36,7 @@ main,
 
   height: 2.3rem;
   width: 9.2rem;
-}
-
-.demo-logo-img {
+  
   background: url(../assets/logo-text.svg) left center no-repeat;
   background-size: contain;
   text-indent: -9999px;

--- a/demo/index.html
+++ b/demo/index.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="demo-theme.css">
 <body>
 	<header>
-	    <a href="../" class="demo-logo demo-logo-img">Minibar</a>
+	    <a href="../" class="demo-logo">Minibar</a>
 
 		<form role="search" class="tsmb-form" data-origin="https://typesense.jquery.com" data-collection="qunitjs_com" data-key="Zh8mMgohXECel9wjPwqT7lekLSG3OCgz" data-foot="true" action="https://duckduckgo.com">
 			<input type="search" name="q" aria-label="Search" placeholder="Search..." autocomplete="off">

--- a/typesense-minibar.css
+++ b/typesense-minibar.css
@@ -7,6 +7,10 @@
   --tsmb-size-sm: 0.8rem;
   --tsmb-size-half: calc(var(--tsmb-size-sm)/2);
   --tsmb-size-input: calc(var(--tsmb-size-base) * 1.2);
+  /* Set to 0 to make the listbox expand to the left */
+  --tsmb-size-listbox-right: auto;
+  --tsmb-size-listbox-width: calc(min(30rem, 60vw));
+  --tsmb-size-listbox-max-height: 70vh;
 
   --tsmb-color-base-background: #fff;
   --tsmb-color-base30: #333;
@@ -51,9 +55,11 @@
 .tsmb-form:focus-within {
   color: var(--tsmb-color-focus30);
 }
+
 .tsmb-form:focus-within input[type=search] {
   background: var(--tsmb-color-focus-background);
 }
+
 .tsmb-form:focus-within input[type=search]::placeholder {
   color: var(--tsmb-color-focus50);
 }
@@ -100,6 +106,10 @@
   display: block !important;
 }
 
+.tsmb-form--slash::after {
+  display: none;
+}
+
 .tsmb-form--slash:not(.tsmb-form--open):not(:focus-within)::after {
   content: '/';
   display: inline-block;
@@ -122,13 +132,16 @@
 .tsmb-form [role=listbox] {
   position: absolute;
   z-index: 10;
-
+  right: var(--tsmb-size-listbox-right);
   background: var(--tsmb-color-focus-background);
   color: var(--tsmb-color-focus30);
-  width: 100%;
-  max-height: 70vh;
+  margin-top: var(--tsmb-size-half);
+  min-width: 100%;
+  width: var(--tsmb-size-listbox-width);
+  max-height: var(--tsmb-size-listbox-max-height);
   overflow: auto;
   border: var(--tsmb-size-edge) solid var(--tsmb-color-focus90);
+  border-radius: var(--tsmb-size-radius);
   box-shadow: 0 var(--tsmb-size-sm) 20px rgba(0,0,0,0.12);
 }
 
@@ -143,9 +156,11 @@
   text-decoration: none;
   border-left: var(--tsmb-size-highlight) solid transparent;
 }
+
 .tsmb-form:not([data-group=true]) [role=option]:not(:first-child) a {
   border-top: var(--tsmb-size-edge) solid var(--tsmb-color-focus90);
 }
+
 .tsmb-form[data-group=true] [role=option] a {
   margin: 0 var(--tsmb-size-base);
   padding: var(--tsmb-size-sm);
@@ -199,33 +214,13 @@
   box-shadow: 0 0 10px rgba(0,0,0,0.12);
   text-decoration: none;
 }
+
 .tsmb-foot::before {
   content: 'Search by';
   color: var(--tsmb-color-focus50);
 }
+
 .tsmb-foot::after {
   content: ' Typesense';
   color: #0300b0;
-}
-
-@media (max-width: 480px) {
-  .tsmb-form {
-    width: 100%;
-  }
-
-  .tsmb-form input[type=search] {
-    border-radius: 0;
-  }
-}
-
-@media (min-width: 768px) {
-  .tsmb-form [role=listbox] {
-    border-radius: var(--tsmb-size-radius);
-    min-width: 500px;
-    margin-top: var(--tsmb-size-half);
-  }
-
-  .tsmb-form--slash::after {
-    display: none;
-  }
 }


### PR DESCRIPTION
This PR attempts to make the default CSS more universal with regard to size. It does a few things:

- Make the listbox size explicitly configurable with custom CSS properties. This includes the width and the height, but also a toggle for forcing the scaling of the listbox to the left. This should make the default CSS easily usable on pages with a wide range of search box locations. The demo page is updated to present this.
- Remove the `@media` sections. They were very opinionated, the current approach is more flexible. The viewport width ranges didn't match each other, so there were actually 3 width ranges, each of them with a different set of CSS attributes. The result was that  only in the wide viewport the listbox was flexible and good looking, and narrowing it caused glitches.
- Move `.tsmb-form--slash::after` sections closer to each other, so it's easier to follow the slash icon behavior
- Clean up white spaces