### PR TITLE
Fix `.tsmb-icon-close` to not rely on inline style attribute

### DIFF
--- a/typesense-minibar.css
+++ b/typesense-minibar.css
@@ -117,8 +117,8 @@ typesense-minibar form::before {
   cursor: pointer;
 }
 
-.tsmb-form--open .tsmb-icon-close {
-  display: block !important;
+form:not(.tsmb-form--open) .tsmb-icon-close {
+  display: none;
 }
 
 .tsmb-form--slash:not(.tsmb-form--open):not(:focus-within)::after {

--- a/typesense-minibar.js
+++ b/typesense-minibar.js
@@ -74,7 +74,7 @@ globalThis.tsminibar = function tsminibar (form, dataset = form.dataset) {
   form.addEventListener('submit', function (e) {
     e.preventDefault();
   });
-  form.insertAdjacentHTML('beforeend', '<svg viewBox="0 0 12 12" width="20" height="20" aria-hidden="true" tabindex="-1" class="tsmb-icon-close" style="display: none;"><path d="M9 3L3 9M3 3L9 9"/></svg>');
+  form.insertAdjacentHTML('beforeend', '<svg viewBox="0 0 12 12" width="20" height="20" aria-hidden="true" tabindex="-1" class="tsmb-icon-close"><path d="M9 3L3 9M3 3L9 9"/></svg>');
   form.querySelector('.tsmb-icon-close').addEventListener('click', function () {
     input.value = '';
     state.hits = [];


### PR DESCRIPTION
This makes the web component compatible with a stict CSP setting, without granting `style-src unsafe-inline`, and without hardcoding a hash of the exact `display: none;` value.

This has been there since the initial commit. This was factored out of the [QUnit website theme](https://github.com/qunitjs/jekyll-theme-amethyst/) originally, and I think I had an idea at some point to make it generated by an HTML template (e.g. Mustache, or something else in Ruby or PHP) where the HTML form should render correctly even without CSS or JS present, so that it is safe to embed in content that may be rendered in e.g. an RSS Feed reader, or Safari Reader mode, without a confusing "x" rendered there when site resources aren't applied. I ended up abandoning this in favour of making it a web component with minimal HTML markup, and instead render anything that only matters to JS, inside JS. This makes it easier to install and upgrade as well.

Anyway, that means we don't need this inline style. We can expect that if a context requested the JS, it also requested the CSS. And we support JS in fewer browsers than the CSS (progressive enhancement, cut the mustard), not the other way around.

 **Alternatives**

I considered the `hidden` attribute, but this doesn't work for `<svg>`. And, would have the downside of requiring us to hardcode `block` which is totally fine for this, but ever so slightly something I'd generally avoid in favour of only encoding how to hide it, since how to show it is already known by default and may vary between different elements.

Ref https://github.com/jquery/infrastructure-puppet/issues/54.
Ref https://github.com/jquery/infrastructure-puppet/pull/57.