### PR TITLE
remove unused `.tsmb-form--slash::after` style

### DIFF
--- a/typesense-minibar.css
+++ b/typesense-minibar.css
@@ -121,10 +121,6 @@ typesense-minibar form::before {
   display: block !important;
 }
 
-.tsmb-form--slash::after {
-  display: none;
-}
-
 .tsmb-form--slash:not(.tsmb-form--open):not(:focus-within)::after {
   content: '/';
   display: inline-block;


### PR DESCRIPTION
Follows-up ca5519d369705429ee, which moved this from applying last, in a media query, to hide the keyboard short cut on narrow viewports (likely touchscreen devices); to instead apply before the actual style unconditionally, thus never actually applying as it is immediately overriden by another style right below it.

The default for `::after`, is already to not exist / be hidden.

Ref https://github.com/jquery/typesense-minibar/pull/2.


----


NOTE: This patches conflicts with https://github.com/jquery/typesense-minibar/pull/3. Given that the limited GitHub PR-model doesn't support patchsets or stacked patches, this means our choices are 1) knowingly submit conflicting patches and rebase which ever is landed last, 2) place one on top of the other and put a disclaimer on the second to not merge it before the first and manually keep the two branches in sync, 3) Put them into one PR and give up CI coverage for the ifrst patch and give up CR separation, 4) work on one thing at a time and keep the other thing to yourself or forget about it, 5) be a maintainer and bypass CR and push directly for one of them.